### PR TITLE
feat: tablePipeAlign false for less tokens

### DIFF
--- a/src/chunkdown.test.ts
+++ b/src/chunkdown.test.ts
@@ -303,7 +303,7 @@ This is a paragraph after the table.`;
 
         expect(chunks).toEqual([
           'This is a paragraph before the table.',
-          '| Column 1 | Column 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |',
+          '| Column 1 | Column 2 |\n| - | - |\n| Cell 1 | Cell 2 |',
           'This is a paragraph after the table.',
         ]);
       });
@@ -866,14 +866,14 @@ Here's a sentence with a footnote[^1].
               "## Tables (GFM)
 
             | Left Aligned | Center Aligned | Right Aligned |
-            | :----------- | :------------: | ------------: |
-            | Cell 1       |     Cell 2     |        Cell 3 |
-            | Long cell    |      Short     |           123 |
+            | :- | :-: | -: |
+            | Cell 1 | Cell 2 | Cell 3 |
+            | Long cell | Short | 123 |
 
-            | Command    | Description                  |
-            | ---------- | ---------------------------- |
-            | git status | Show working tree status     |
-            | git diff   | Show changes between commits |",
+            | Command | Description |
+            | - | - |
+            | git status | Show working tree status |
+            | git diff | Show changes between commits |",
               "## Blockquotes
 
             > Simple blockquote
@@ -945,12 +945,12 @@ Here's a sentence with a footnote[^1].
                > with multiple lines",
               "### Table with Complex Content
 
-            | Element | Syntax Variants          | Example                        |
-            | ------- | ------------------------ | ------------------------------ |
-            | Bold    | \`**text**\` or \`__text__\` | **bold** and **bold**          |
-            | Italic  | \`*text*\` or \`_text_\`     | *italic* and *italic*          |
-            | Code    | \`\\\`text\\\`\\\`              | \`code\`                         |
-            | Link    | \`[text](url)\`            | [example](https://example.com) |",
+            | Element | Syntax Variants | Example |
+            | - | - | - |
+            | Bold | \`**text**\` or \`__text__\` | **bold** and **bold** |
+            | Italic | \`*text*\` or \`_text_\` | *italic* and *italic* |
+            | Code | \`\\\`text\\\`\\\` | \`code\` |
+            | Link | \`[text](url)\` | [example](https://example.com) |",
               "## Edge Cases
 
             Empty lines:
@@ -1100,14 +1100,14 @@ Here's a sentence with a footnote[^1].
               "## Tables (GFM)
 
             | Left Aligned | Center Aligned | Right Aligned |
-            | :----------- | :------------: | ------------: |
-            | Cell 1       |     Cell 2     |        Cell 3 |
-            | Long cell    |      Short     |           123 |
+            | :- | :-: | -: |
+            | Cell 1 | Cell 2 | Cell 3 |
+            | Long cell | Short | 123 |
 
-            | Command    | Description                  |
-            | ---------- | ---------------------------- |
-            | git status | Show working tree status     |
-            | git diff   | Show changes between commits |",
+            | Command | Description |
+            | - | - |
+            | git status | Show working tree status |
+            | git diff | Show changes between commits |",
               "## Blockquotes
 
             > Simple blockquote
@@ -1181,12 +1181,12 @@ Here's a sentence with a footnote[^1].
                > with multiple lines",
               "### Table with Complex Content
 
-            | Element | Syntax Variants          | Example                        |
-            | ------- | ------------------------ | ------------------------------ |
-            | Bold    | \`**text**\` or \`__text__\` | **bold** and **bold**          |
-            | Italic  | \`*text*\` or \`_text_\`     | *italic* and *italic*          |
-            | Code    | \`\\\`text\\\`\\\`              | \`code\`                         |
-            | Link    | \`[text](url)\`            | [example](https://example.com) |",
+            | Element | Syntax Variants | Example |
+            | - | - | - |
+            | Bold | \`**text**\` or \`__text__\` | **bold** and **bold** |
+            | Italic | \`*text*\` or \`_text_\` | *italic* and *italic* |
+            | Code | \`\\\`text\\\`\\\` | \`code\` |
+            | Link | \`[text](url)\` | [example](https://example.com) |",
               "## Edge Cases
 
             Empty lines:

--- a/src/markdown.test.ts
+++ b/src/markdown.test.ts
@@ -74,7 +74,7 @@ describe('Markdown', () => {
 
       const result = toMarkdown(ast);
       expect(result).toContain('| Header 1 | Header 2 |');
-      expect(result).toContain('| Cell 1   | Cell 2   |');
+      expect(result).toContain('| Cell 1 | Cell 2 |');
     });
 
     it('should handle task lists', () => {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -44,7 +44,11 @@ export const fromMarkdown = (value: Value): Root => {
 
 export const toMarkdown = (tree: Nodes): string => {
   return mdastToMarkdown(tree, {
-    extensions: [gfmToMarkdown()],
+    extensions: [
+      gfmToMarkdown({
+        tablePipeAlign: false,
+      }),
+    ],
   });
 };
 

--- a/src/splitters/table.test.ts
+++ b/src/splitters/table.test.ts
@@ -1,4 +1,3 @@
-import { f } from 'f-strings';
 import { describe, expect, it } from 'vitest';
 import { TableSplitter } from './table';
 
@@ -20,8 +19,8 @@ describe('TableSplitter', () => {
 
     expect(chunks.length).toBe(1);
     expect(chunks).toEqual([
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |
 | Row A3 | Row B3 |
@@ -39,12 +38,12 @@ describe('TableSplitter', () => {
 
     expect(chunks.length).toBe(2);
     expect(chunks).toEqual([
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |`,
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A3 | Row B3 |
 | Row A4 | Row B4 |`,
     ]);
@@ -60,17 +59,17 @@ describe('TableSplitter', () => {
 
     expect(chunks.length).toBe(4);
     expect(chunks).toEqual([
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |`,
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A2 | Row B2 |`,
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A3 | Row B3 |`,
-      `| Col A  | Col B  |
-| ------ | ------ |
+      `| Col A | Col B |
+| - | - |
 | Row A4 | Row B4 |`,
     ]);
   });
@@ -86,12 +85,12 @@ describe('TableSplitter', () => {
 
       expect(chunks.length).toBe(2);
       expect(chunks).toEqual([
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |`,
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A3 | Row B3 |
 | Row A4 | Row B4 |`,
       ]);
@@ -107,12 +106,12 @@ describe('TableSplitter', () => {
 
       expect(chunks.length).toBe(2);
       expect(chunks).toEqual([
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |`,
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A3 | Row B3 |
 | Row A4 | Row B4 |`,
       ]);
@@ -129,8 +128,8 @@ describe('TableSplitter', () => {
 
       expect(chunks.length).toBe(1);
       expect(chunks[0]).toBe(
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |
 | Row A3 | Row B3 |
@@ -148,12 +147,12 @@ describe('TableSplitter', () => {
 
       expect(chunks.length).toBe(2);
       expect(chunks).toEqual([
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |`,
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A3 | Row B3 |
 | Row A4 | Row B4 |`,
       ]);
@@ -169,8 +168,8 @@ describe('TableSplitter', () => {
 
       expect(chunks.length).toBe(1);
       expect(chunks).toEqual([
-        `| Col A  | Col B  |
-| ------ | ------ |
+        `| Col A | Col B |
+| - | - |
 | Row A1 | Row B1 |
 | Row A2 | Row B2 |
 | Row A3 | Row B3 |


### PR DESCRIPTION
I am suggesting that we disable the pretty tablePipeAlign since a LLM is the intended audience. OR We could allow the toMarkdown handler to be passed in via options. Let me know what you think/prefer.

This will help [me] when dealing with policy tables where 1 or 2 of the cells have 100 characters resulting in a markdown table with a bunch of unecessary  empty spaces and dashes which ultimately triggers an unecessary table split on large reference tables.

PS: Awesome package, sooo glad I found it. (via npm while looking for projects using mdast)